### PR TITLE
Allow templates to be used for target directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
+  - "0.12"
+  - "4.0"
 before_script: 
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/tasks/tar.gz.js
+++ b/tasks/tar.gz.js
@@ -27,7 +27,7 @@ function init(grunt) {
 			countDown = _.after(files.length, done);
 
 		files.forEach(function (file) {
-			compress.extract(file.src, file.target, function (err) {
+			compress.extract(file.src, grunt.config.process(file.target), function (err) {
 				if (err) {
 					grunt.util.warn(err);
 					done(err);


### PR DESCRIPTION
This allows for the configurations of the sort:

targz: {
    standalone_win: {
        files: {
            "<%= appConfig.build.mpegDir %>":  "tmp/win/mpg123n-nw.tgz"
        }
    }
}
