### PR TITLE
Upate link to node-tar.gz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-tar.gz [![Build Status](https://secure.travis-ci.org/bendi/grunt-tar.gz.png?branch=master)](http://travis-ci.org/bendi/grunt-tar.gz)
 
-Grunt task around [tar.gz](https://github.com/jsoverson/tar.gz) npm module
+Grunt task around [node-tar.gz](https://github.com/alanhoff/node-tar.gz) npm module
 
 
 ## Getting Started


### PR DESCRIPTION
Link was dead. Repo seems to be removed.
